### PR TITLE
Enabled sni in jetforce_diagnostics.py

### DIFF
--- a/jetforce_diagnostics.py
+++ b/jetforce_diagnostics.py
@@ -141,7 +141,7 @@ class BaseCheck:
         with socket.create_connection(
             (self.args.host, self.args.port), timeout=5
         ) as sock:
-            with context.wrap_socket(sock) as ssock:
+            with context.wrap_socket(sock, server_hostname = self.netloc) as ssock:
                 yield ssock
 
     def make_request(self, url: str) -> GeminiResponse:


### PR DESCRIPTION
Enabled sni by adding "server_hostname" to the wrap_socket call. Without it vhost won't work.